### PR TITLE
"messenger" instead of "angel" in three verses of Revelation

### DIFF
--- a/translatedTexts/ReadersVersion/OET-RV_REV.ESFM
+++ b/translatedTexts/ReadersVersion/OET-RV_REV.ESFM
@@ -334,8 +334,8 @@
 \v 7 but¦161188 at the time when the seventh¦161195 messenger¦161196 will speak and blow his trumpet¦161202, then the hidden purposes of \nd God¦161209\nd* will come to be, just like he told his slaves¦161215 the prophets¦161221 \add long ago\add*.”
 \p
 \v 8 Then¦161223 the one whom I had heard¦161227 speak¦161232 from heaven¦161230 spoke to me again¦161231, saying¦161237, “Go and get the open scroll¦161242 from the hand¦161250 of the messenger¦161252 who is straddling the ocean and the land.”\x + \xo 10:8-10: \xt Exo 2:8–3:3.\x*
-\v 9 So¦161262 I went¦161263 to the angel and asked him to give¦161270 me the little¦161275 scroll¦161275, and he answered, “Take it and eat it. At first it'll taste sweet¦161298 like honey¦161300, but afterwards it'll be uncomfortable in your¦161288 stomach¦161291.”
-\v 10 So¦161301 I took¦161302 that little¦161305 scroll¦161305 from the angel's hand¦161309 and ate¦161327 it, and it tasted sweet¦161324 like honey¦161323, but my¦161320 stomach¦161332 hurt afterwards
+\v 9 So¦161262 I went¦161263 to the messenger and asked him to give¦161270 me the little¦161275 scroll¦161275, and he answered, “Take it and eat it. At first it'll taste sweet¦161298 like honey¦161300, but afterwards it'll be uncomfortable in your¦161288 stomach¦161291.”
+\v 10 So¦161301 I took¦161302 that little¦161305 scroll¦161305 from the messenger's hand¦161309 and ate¦161327 it, and it tasted sweet¦161324 like honey¦161323, but my¦161320 stomach¦161332 hurt afterwards
 \v 11 and they¦161335 told me, “You have to speak out God's message about many nations¦161346 and people¦161343 groups and language groups and kings¦161350.”
 \c 11
 \s1 The two witnesses
@@ -555,7 +555,7 @@
 \v 13 They're \add all unified\add*, and they¦164979 give their¦164976 power¦164971 and authority¦164974 to the wild animal¦164978.
 \v 14 They'll go to battle against the lamb, but the lamb will conquer them because¦164991 he is \nd master¦164992\nd* of masters¦164993 and king¦164996 of kings¦164997 and the ones with him are called¦165002 and chosen¦165004 and faithful¦165006.”
 \p
-\v 15 Then¦165007 the angel said to me, “The waters¦165013 that you¦165015 saw¦165015, where¦165017 the prostitute¦165019 sits, are peoples¦165022 and multitudes and nations¦165027 and languages¦165029.
+\v 15 Then¦165007 the messenger said to me, “The waters¦165013 that you¦165015 saw¦165015, where¦165017 the prostitute¦165019 sits, are peoples¦165022 and multitudes and nations¦165027 and languages¦165029.
 \v 16 The ten¦165032 horns¦165033 that you saw¦165035 and the wild animal¦165040, they'll hate the prostitute¦165045 and will make her desolated¦165047 and naked¦165051 and they'll eat her flesh¦165056 and will burn her completely with fire¦165063,
 \v 17 because¦165065 God has put it into their hearts¦165070 to do his¦165076 purpose and to do one purpose and to give¦165083 their kingdom¦165085 to the wild animal¦165089 until¦165090 God's words turn into reality.
 \p


### PR DESCRIPTION
Just to maintain consistency with the rest of the Readers' Version translated text of Revelation.