### PR TITLE
Typo fixes in Acts 12

### DIFF
--- a/translatedTexts/ReadersVersion/OET-RV_ACT.ESFM
+++ b/translatedTexts/ReadersVersion/OET-RV_ACT.ESFM
@@ -759,9 +759,9 @@
 \p
 \v 20 Now King Herod was disputing with the people of Tyre¦92460 and Tsidon, and so they got together and persuaded¦92478 Blastos¦92479, a close personal servant of the king, to be their¦92493 spokesman in asking for peace¦92489 because¦92490 they were dependent on food from the king's provinces.
 \p
-\v 21 On the agreed day¦92505, Herod¦92507 dressed¦92508 in his royal¦92510 garments and seated on his throne, started to address¦92516 them.
+\v 21 On the agreed day¦92505, Herod¦92507, dressed¦92508 in his royal¦92510 garments and seated on his throne, started to address¦92516 them.
 \v 22 The crowd shouted out, “This is the voice¦92529 of a \nd god¦92528\nd*, not of a man.”
-\v 23 Because he didn't¦92545 attribute the honour to \nd God¦92550\nd*, one the \nd master's¦92542\nd* messengers¦92541 immediately¦92536 struck¦92539 him down and he stopped¦92562 breathing¦92562 as a result of a worm infestation.
+\v 23 Because he didn't¦92545 attribute the honour to \nd God¦92550\nd*, one of the \nd master's¦92542\nd* messengers¦92541 immediately¦92536 struck¦92539 him down and he stopped¦92562 breathing¦92562 as a result of a worm infestation.
 \p
 \v 24 Meanwhile God's message¦92565 continued to spread and¦92571 multiply¦92572.
 \p


### PR DESCRIPTION
Added a useful comma and a missing _of_.