### PR TITLE
Typo corrections in Acts 13

### DIFF
--- a/translatedTexts/ReadersVersion/OET-RV_ACT.ESFM
+++ b/translatedTexts/ReadersVersion/OET-RV_ACT.ESFM
@@ -1,4 +1,4 @@
-\id ACT - Open English Translation—Readers' Version (OET-RV) v0.3.04
+\id ACT - Open English Translation—Readers' Version (OET-RV) v0.3.05
 \usfm 3.0
 \ide UTF-8
 \rem ESFM v0.6 ACT
@@ -787,7 +787,7 @@
 \v 5 When they arrived in \add the town of\add* Salamis¦92700, they proclaimed¦92703 God's message¦92706 in the Jewish¦92712 meeting¦92712 halls¦92712. They also had Yohan¦92718 as their assistant.
 \s1 Sergius believes after Bar-Jesus is blinded
 \p
-\v 6 They travelled around the island¦92729 and when they got to Paphos¦92731, they met a Jewish man¦92735 named Bar-Jesus.\f + \fr 13:6 \ft The Greek form of his name was Elymas according to verse 8.\f* He was a sorcerer and false¦92739 prophet¦92739
+\v 6 They travelled around the island¦92729 and when they got to Pafos¦92731, they met a Jewish man¦92735 named Bar-Jesus.\f + \fr 13:6 \ft The Greek form of his name was Elymas according to verse 8.\f* He was a sorcerer and false¦92739 prophet¦92739
 \v 7 who was with Sergius Paulus the proconsul¦92753, an intelligent¦92757 man¦92756. Sergius sent for Barnabas¦92761 and Saul¦92763 because he wanted to hear¦92768 God's message¦92770 from them,
 \v 8 but¦92774 the sorcerer opposed them and tried to prevent Sergius¦92776 from believing.
 \v 9 So then Saul¦92796 (the \add Roman\add* form of his name was Paul¦92800), filled¦92801 with the holy \nd spirit¦92802\nd* looked¦92805 intently¦92805 at Bar-Jesus
@@ -805,7 +805,7 @@
 \v 14 Paul and his companions, went on from Perga¦92919 to Pisidian¦92927 Antioch¦92923, where they entered the Jewish¦92933 meeting¦92933 hall¦92933 on the Rest Day and sat¦92942 down \add with the congregation\add*.
 \v 15 After the readings¦92946 from the Law and from the Prophets,\f + \fr 13:15 \ft The Hebrew Scriptures are divided into the Law, the Prophets, and the Writings.\f* the leaders¦92954 sent¦92952 a messenger over to them to ask, “Men, brothers¦92959, if you¦92967 bring any message¦92968 of encouragement for the congregation, please share it¦92973.”
 \p
-\v 16 So¦92975 Paul¦92977 stood¦92974 up and, motioning with his hand¦92981, started speaking, “Fellow Israelis and every who reveres¦92988 \nd God¦92990\nd*, listen¦92991 to me.
+\v 16 So¦92975 Paul¦92977 stood¦92974 up and, motioning with his hand¦92981, started speaking, “Fellow Israelis and everyone who reveres¦92988 \nd God¦92990\nd*, listen¦92991 to me.
 \v 17 The \nd God¦92993\nd* of the people of Israel¦92998 chose¦92999 our¦93002 ancestors¦93001 and helped the people to prosper when they were staying in Egypt¦93015. Then later he showed his power as he led them out
 \v 18 and¦93024 endured¦93031 them in the wilderness¦93035 for around forty years.
 \v 19 Then having¦93037 overthrown seven¦93039 nations¦93038 in Caanan,\x + \xo 13:19: a \xt Deu 7:1; \xo b \xt Josh 14:1.\x* he passed on that land as an inheritance
@@ -844,7 +844,7 @@
 \q1 Even if someone¦93534 described¦93535 it clearly to you all, you still might not believe¦93532 it.’ ”
 \p
 \v 42 As they¦93548 left the meeting hall after¦93555 the service, the people invited them to speak again the following Rest Day.
-\v 43 But¦93565 when they starting walking away, many people followed¦93569 after¦93578 Paul¦93578 and Barnabas¦93581, who then addressed¦93583 them and encouraged them to continue trusting in God's grace¦93592.
+\v 43 But¦93565 when they started walking away, many people followed¦93569 after¦93578 Paul¦93578 and Barnabas¦93581, who then addressed¦93583 them and encouraged them to continue trusting in God's grace¦93592.
 \rem /s1 Paul Turns to the Gentiles
 \p
 \v 44 So¦93608 on the following Rest Day, nearly everyone in the city¦93616 had gathered¦93617 there to hear¦93618 the message¦93624 from \nd God¦93629\nd*.


### PR DESCRIPTION
_Pafos_, not _Paphos_, in verse 6, for consistency with verse 13, and a couple of words corrected.