### PR TITLE
Acts 2: clarify the execution on a post

### DIFF
--- a/translatedTexts/ReadersVersion/OET-RV_ACT.ESFM
+++ b/translatedTexts/ReadersVersion/OET-RV_ACT.ESFM
@@ -121,7 +121,7 @@
 \v 21 Then¦83444 everyone¦83446 who relies on the name¦83452 and authority of the \nd master¦83454\nd* will be saved¦83455.’
 \p
 \v 22 “Fellow Israelis, listen¦83459 to this account: You yourselves¦83493 know that God did miracles¦83476 through \nd Yeshua¦83463\nd* from \nd Nazareth¦83465\nd*, and he fulfilled signs¦83480 \add from the scriptures\add*—in fact God did this right in front of you.
-\v 23 \x + \xo 2:23: \xt Mat 27:35; Mrk 15:24; Luk 23:33; Yhn 19:18.\x*Then as part of God's plan and foreknowledge¦83500, this Yeshua was taken to the authorities by those who didn't follow their own laws, and you¦83510 all killed¦83510 him by having him executed¦83509 on a pole.
+\v 23 \x + \xo 2:23: \xt Mat 27:35; Mrk 15:24; Luk 23:33; Yhn 19:18.\x*Then as part of God's plan and foreknowledge¦83500, this Yeshua was taken to the authorities by those who didn't follow their own laws, and you¦83510 all killed¦83510 him by having him \add nailed to\add*\x + \xo 2:23: \xt Jhn 20:25.\x* a post.
 \v 24 \x + \xo 2:24: \xt Mat 28:5-6; Mrk 16:6; Luk 24:5.\x*But \nd God¦83514\nd* released him from the agonies¦83518 of death and brought him back to life—death couldn't restrain¦83526 him.
 \v 25 \x + \xo 2:25-28: \xt Psa 16:8-11 (LXX).\x*As David¦83530 wrote,
 \q1 ‘I foresaw¦83537 the \nd master¦83539\nd* always being in front of me. I refuse to be afraid because¦83545 he's there on my¦83548 right¦83547.
@@ -140,7 +140,7 @@
 \q1
 \v 35 until¦83766 I defeat your¦83772 enemies¦83771.’
 \p
-\v 36 “So let all Israel¦83784 know that this \nd Yeshua¦83801\nd* that you¦83803 executed¦83804 on a pole, \nd God¦83796\nd* made him¦83789 both the \nd master¦83787\nd* and¦83790 the \nd messiah¦83791\nd*.”
+\v 36 “So let all Israel¦83784 know that this \nd Yeshua¦83801\nd* that you¦83803 executed¦83804 on a post, \nd God¦83796\nd* made him¦83789 both the \nd master¦83787\nd* and¦83790 the \nd messiah¦83791\nd*.”
 \rem /s1 The First Converts
 \p
 \v 37 When the people heard¦83810 that, they were deeply troubled and asked Peter¦83827 and the other¦83830 missionaries, “What should we¦83834 do then, brothers¦83837?”


### PR DESCRIPTION
This reading is coming up soon for me, but I've put it in a different branch on my fork, in case you want longer to think about it.

I thought both "killed" and "executed" in verse 23 already seemed a bit repetitive, and would get a bit unwieldy with the "nailed" clarification added to it.

On the other hand, since verse 36 is in the same section, the nails probably don't need to be mentioned a second time.

And I've changed "pole" to "post" in both verses.

As always, I'm open to other suggestions.