### PR TITLE
Reflections 6‒10, Songs 33 and 50, Genesis 15, Hebrews 11, Luke 12: minor changes

### DIFF
--- a/translatedTexts/ReadersVersion/OET-RV_ECC.ESFM
+++ b/translatedTexts/ReadersVersion/OET-RV_ECC.ESFM
@@ -730,7 +730,7 @@
 \v 11 If a snake bites before it's charmed,
 \q1 the snake charmer \add ≈won't be able to charge\add* \add for the show\add*.
 \q1
-\v 12 A wise person's words earns them favour,
+\v 12 A wise person's words earn them favour,
 \q1 but a fool's lips destroy him—
 \q1
 \v 13 \add ≈as soon as he opens his mouth, foolishness comes out\add*,
@@ -738,7 +738,7 @@
 \q1
 \v 14 Then the fool \add ≈continues again with more nonsense\add*.
 \b
-\q1 No one knows what will happen \add next\add*?
+\q1 No one knows what will happen \add next\add*.
 \q1 Who can tell \add ≈you\add* what \add ≈will happen in the future\add*?
 \q1
 \v 15 A foolish person's work wears him out,

--- a/translatedTexts/ReadersVersion/OET-RV_ECC.ESFM
+++ b/translatedTexts/ReadersVersion/OET-RV_ECC.ESFM
@@ -620,7 +620,7 @@
 \v 17 and I saw everything that God does—
 \q1 realising that humanity can't discover everything that's done \add ≈in this world\add*—
 \q1 they'll try to discover it but fail.
-\q1 Every if a wise person claimed to know,
+\q1 Even if a wise person claimed to know,
 \q1 they wouldn't be able to discover it.
 \c 9
 \rem /s1 Death Comes to All; Take Life as It Comes; A Common Destiny for All

--- a/translatedTexts/ReadersVersion/OET-RV_ECC.ESFM
+++ b/translatedTexts/ReadersVersion/OET-RV_ECC.ESFM
@@ -1,4 +1,4 @@
-\id ECC - Open English Translation—Readers' Version (OET-RV) v0.1.01
+\id ECC - Open English Translation—Readers' Version (OET-RV) v0.1.02
 \usfm 3.0
 \ide UTF-8
 \rem ESFM v0.6 ECC
@@ -441,7 +441,7 @@
 \q1
 \rem /s1 The Future—Determined and Unknown
 \v 10 Everything that existed¦280259 has already¦280260 been named¦280261.
-\q1 It's know what humankind¦280267 is
+\q1 It's known what humankind¦280267 is
 \q1 and that \add @humans\add* can't¦280268 dispute¦280271 with the \add one\add* who's stronger¦280273 than them.
 \q1
 \v 11 \add ≈Yes,\add* many words¦280280 \add just\add* become more pointless.

--- a/translatedTexts/ReadersVersion/OET-RV_GEN.ESFM
+++ b/translatedTexts/ReadersVersion/OET-RV_GEN.ESFM
@@ -1,4 +1,4 @@
-\id GEN - Open English Translation—Readers' Version (OET-RV) v0.1.26
+\id GEN - Open English Translation—Readers' Version (OET-RV) v0.1.27
 \usfm 3.0
 \ide UTF-8
 \rem ESFM v0.6 GEN
@@ -652,7 +652,7 @@
 \v 11 Then¦5993 \add some\add* birds¦5988 of prey flew down to the carcasses¦5991, \add but\add* Abram¦5994 shooed them away.
 \p
 \v 12 Later as the sun¦5997 was going¦5998 down, Abram¦6003 fell into a deep sleep¦5999, and it suddenly became completely dark and he became terrified,\x + \xo 15:12: \xt Yob 4:13-14.\x*
-\v 13 and \add Yahweh\add* said¦6011 to Abram¦6012, “Know for certain¦6013 that your descendants will be strangers in a land that doesn't belong to them, and they will serve the \add rulers of that land\add* and \add those rulers\add* will persecute them for 400 years.\x + \xo 15:13: \xt Exo 1:1-14; Acts 7:6.\x*
+\v 13 and \add Yahweh\add* said¦6011 to Abram¦6012, “Know for certain¦6013 that your descendants will be strangers in a land that doesn't belong to them, and they'll serve the \add rulers of that land\add* and \add those rulers\add* will persecute them for 400 years.\x + \xo 15:13: \xt Exo 1:1-14; Acts 7:6.\x*
 \v 14 \add But¦6031 just as certain\add*, I'll¦6038 punish the nation¦6034 that they serve¦6036 and after¦6039 that they'll come¦6042 out with many possessions¦6043.\x + \xo 15:14: \xt Exo 12:40-41; Acts 7:7.\x*
 \v 15 And \add as for\add* you, you'll go¦6047 to your ancestors¦6050 in peace¦6051—you'll be buried¦6052 at a good¦6054 old age.
 \v 16 Then¦6056 in the fourth¦6057 generation¦6056 \add your descendants\add* will come back here, because the Amorites' sins won't¦6061 be complete¦6063 until¦6066 then.”

--- a/translatedTexts/ReadersVersion/OET-RV_HEB.ESFM
+++ b/translatedTexts/ReadersVersion/OET-RV_HEB.ESFM
@@ -1,4 +1,4 @@
-\id HEB - Open English Translation—Readers' Version (OET-RV) v0.1.50
+\id HEB - Open English Translation—Readers' Version (OET-RV) v0.1.51
 \usfm 3.0
 \ide UTF-8
 \rem ESFM v0.6 HEB
@@ -458,7 +458,7 @@
 \v 15 if they'd been meaning the place that they left, they would¦146059 have \add already\add* had time¦146060 to go back there—
 \v 16 so now they're aspiring¦146066 to a better¦146065 place, i.e., a heavenly¦146069 home. Therefore¦146070 God isn't¦146071 ashamed¦146072 of them or of being called¦146077 their¦146073 God, because¦146080 he has prepared¦146079 a city¦146082 for them.
 \p
-\v 17 By faith¦146083, Abraham¦146085 when he was tested¦146088 offered up Isaac¦146087.\x + \xo 11:17: \xt Gen 22:1-14.\x* He had received the promises¦146095 and offered his only son that he'd given birth to—
+\v 17 By faith¦146083, Abraham¦146085 when he was tested¦146088 offered up Isaac¦146087.\x + \xo 11:17: \xt Gen 22:1-14.\x* He had received the promises¦146095 and offered his only son—
 \v 18 the one about which it¦146099 had been said: ‘Your descendants¦146105 will be named¦146103 through Isaac¦146102.’
 \v 19 Abraham had reckoned that \nd God¦146116\nd* was powerful¦146113 enough to bring him back to life from the dead¦146110, and in a manner of speaking, that's what happened.
 \p

--- a/translatedTexts/ReadersVersion/OET-RV_LUK.ESFM
+++ b/translatedTexts/ReadersVersion/OET-RV_LUK.ESFM
@@ -1,4 +1,4 @@
-\id LUK - Open English Translation—Readers' Version (OET-RV) v0.2.57
+\id LUK - Open English Translation—Readers' Version (OET-RV) v0.2.58
 \usfm 3.0
 \ide UTF-8
 \rem ESFM v0.6 LUK
@@ -1159,7 +1159,7 @@
 \v 23 \wj because¦51140 your life¦51141 is more than food and your body¦51149 is more than clothing¦51151.\wj*
 \v 24 \wj Look at the ravens¦51159. They don't¦51162 plant seeds or harvest crops and they have no storerooms¦51171 or barns, yet \+nd God¦51178\+nd* keeps them fed, and \+add humans\+add* are worth a lot more than birds¦51188.\wj*
 \v 25 \wj Which of you¦51192 can add even an hour¦51201 to your¦51191 life by spending more time worrying¦51193?\wj*
-\v 26 \wj So¦51204 if you can't¦51205 even do something small like that, why worry¦51217 about¦51213 bigger things.\wj*
+\v 26 \wj So¦51204 if you can't¦51205 even do something small like that, why worry¦51217 about¦51213 bigger things?\wj*
 \v 27 \x + \xo 12:27: \xt 1Ki 10:4-7; 2Ch 9:3-6.\x*\wj Look at how the lilies¦51220 grow. They don't¦51234 go to work or make \+add fabric\+add*, yet even \+add King\+add* Solomon¦51235 at the height of his¦51240 fame wasn't dressed as well as one of them.\wj*
 \v 28 \wj So if \+nd God¦51270\+nd* dresses¦51272 the weeds in the paddock that are here today¦51263 and incinerated tomorrow¦51265, how much more would he look after you all—you with little¦51279 faith¦51279?\wj*
 \p

--- a/translatedTexts/ReadersVersion/OET-RV_PSA.ESFM
+++ b/translatedTexts/ReadersVersion/OET-RV_PSA.ESFM
@@ -1678,7 +1678,7 @@
 \v 5 He loves \add ≈what is right¦248225 and just\add*.
 \q1 Yahweh's loyal¦248227 commitment \add ≈can be seen all over the world\add*.
 \q1
-\v 6 At Yahweh' command, the heavens¦248234 were made,
+\v 6 At Yahweh's command, the heavens¦248234 were made,
 \q1 ≈and¦248236 all the stars were made by the breath¦248236 of his mouth¦248237.
 \q1
 \v 7 He gathers¦248242 the waters¦248244 of the sea¦248245 together like a heap.

--- a/translatedTexts/ReadersVersion/OET-RV_PSA.ESFM
+++ b/translatedTexts/ReadersVersion/OET-RV_PSA.ESFM
@@ -1,4 +1,4 @@
-\id PSA - Open English Translation—Readers' Version (OET-RV) v0.2.01
+\id PSA - Open English Translation—Readers' Version (OET-RV) v0.2.02
 \usfm 3.0
 \ide UTF-8
 \rem ESFM v0.6 PSA
@@ -2831,7 +2831,7 @@
 \q1 \add However,\add* I'll scold you
 \q1 ≈and bring up all the things you have done, right in front of your eyes.
 \q1
-\v 22 Give this \add careful\add* consideration, you all who forget God¦251945,
+\v 22 Give this \add careful\add* consideration, all of you who forget God¦251945,
 \q1 otherwise I will tear you to pieces,
 \q1 and¦251941 there'll be no one to rescue you.
 \q1


### PR DESCRIPTION
The change to Hebrews 11:17 is more than just a typo fix; I removed several words, but μονογενὴς and μονογενής in Luke 8:42 and 9:38, for example, are simply translated as "only daughter" and "only child", respectively, without any reference to the giving birth, so I thought it would be reasonable to remove that reference from Hebrews 11:17, to avoid leading people to conclusions perhaps even more surprising than Sarah's old-age motherhood.